### PR TITLE
Remove -Werror build flag

### DIFF
--- a/scd30/Makefile
+++ b/scd30/Makefile
@@ -3,7 +3,7 @@ scd_common_dir := .
 sw_i2c_dir := ${sensirion_common_dir}/sw_i2c
 hw_i2c_dir := ${sensirion_common_dir}/hw_i2c
 
-CFLAGS := -Os -Wall -Werror -I. -I${sensirion_common_dir}
+CFLAGS := -Os -Wall -I. -I${sensirion_common_dir}
 
 sensirion_common_objects := sensirion_common.o
 scd_common_objects := scd_git_version.o


### PR DESCRIPTION
Remove -Werror build flag to avoid breaking builds due to future
compiler warnings or warnings due to different compilers...