### PR TITLE
Automated type conversion

### DIFF
--- a/scd30/scd30.c
+++ b/scd30/scd30.c
@@ -36,9 +36,9 @@
 #include "sensirion_i2c.h"
 
 #ifdef SCD_ADDRESS
-static const u8 SCD_I2C_ADDRESS = SCD_ADDRESS;
+static const uint8_t SCD_I2C_ADDRESS = SCD_ADDRESS;
 #else
-static const u8 SCD_I2C_ADDRESS = 0x61;
+static const uint8_t SCD_I2C_ADDRESS = 0x61;
 #endif
 
 #define SCD_CMD_START_PERIODIC_MEASUREMENT 0x0010
@@ -56,7 +56,7 @@ static const u8 SCD_I2C_ADDRESS = 0x61;
 #define SCD_CMD_SINGLE_WORD_BUF_LEN                                            \
     (SENSIRION_COMMAND_SIZE + SENSIRION_WORD_SIZE + CRC8_LEN)
 
-s16 scd_start_periodic_measurement(u16 ambient_pressure_mbar) {
+int16_t scd_start_periodic_measurement(uint16_t ambient_pressure_mbar) {
     if (ambient_pressure_mbar &&
         (ambient_pressure_mbar < 700 || ambient_pressure_mbar > 1400)) {
         /* out of allowable range */
@@ -68,17 +68,18 @@ s16 scd_start_periodic_measurement(u16 ambient_pressure_mbar) {
         &ambient_pressure_mbar, SENSIRION_NUM_WORDS(ambient_pressure_mbar));
 }
 
-s16 scd_stop_periodic_measurement() {
+int16_t scd_stop_periodic_measurement() {
     return sensirion_i2c_write_cmd(SCD_I2C_ADDRESS,
                                    SCD_CMD_STOP_PERIODIC_MEASUREMENT);
 }
 
-s16 scd_read_measurement(f32 *co2_ppm, f32 *temperature, f32 *humidity) {
-    s16 ret;
+int16_t scd_read_measurement(float32_t *co2_ppm, float32_t *temperature,
+                             float32_t *humidity) {
+    int16_t ret;
     union {
-        u32 u32_value;
-        f32 float32;
-        u16 words[2];
+        uint32_t u32_value;
+        float32_t float32;
+        uint16_t words[2];
     } tmp, data[3];
 
     ret = sensirion_i2c_read_cmd(SCD_I2C_ADDRESS, SCD_CMD_READ_MEASUREMENT,
@@ -101,8 +102,8 @@ s16 scd_read_measurement(f32 *co2_ppm, f32 *temperature, f32 *humidity) {
     return STATUS_OK;
 }
 
-s16 scd_set_measurement_interval(u16 interval_sec) {
-    s16 ret;
+int16_t scd_set_measurement_interval(uint16_t interval_sec) {
+    int16_t ret;
 
     if (interval_sec < 2 || interval_sec > 1800) {
         /* out of allowable range */
@@ -117,13 +118,13 @@ s16 scd_set_measurement_interval(u16 interval_sec) {
     return ret;
 }
 
-s16 scd_get_data_ready(u16 *data_ready) {
+int16_t scd_get_data_ready(uint16_t *data_ready) {
     return sensirion_i2c_read_cmd(SCD_I2C_ADDRESS, SCD_CMD_GET_DATA_READY,
                                   data_ready, SENSIRION_NUM_WORDS(*data_ready));
 }
 
-s16 scd_set_temperature_offset(u16 temperature_offset) {
-    s16 ret;
+int16_t scd_set_temperature_offset(uint16_t temperature_offset) {
+    int16_t ret;
 
     ret = sensirion_i2c_write_cmd_with_args(
         SCD_I2C_ADDRESS, SCD_CMD_SET_TEMPERATURE_OFFSET, &temperature_offset,
@@ -133,8 +134,8 @@ s16 scd_set_temperature_offset(u16 temperature_offset) {
     return ret;
 }
 
-s16 scd_set_altitude(u16 altitude) {
-    s16 ret;
+int16_t scd_set_altitude(uint16_t altitude) {
+    int16_t ret;
 
     ret = sensirion_i2c_write_cmd_with_args(SCD_I2C_ADDRESS,
                                             SCD_CMD_SET_ALTITUDE, &altitude,
@@ -144,23 +145,23 @@ s16 scd_set_altitude(u16 altitude) {
     return ret;
 }
 
-s16 scd_get_automatic_self_calibration(u8 *asc_enabled) {
-    u16 word;
-    s16 ret;
+int16_t scd_get_automatic_self_calibration(uint8_t *asc_enabled) {
+    uint16_t word;
+    int16_t ret;
 
     ret = sensirion_i2c_read_cmd(SCD_I2C_ADDRESS, SCD_CMD_AUTO_SELF_CALIBRATION,
                                  &word, SENSIRION_NUM_WORDS(word));
     if (ret != STATUS_OK)
         return ret;
 
-    *asc_enabled = (u8)word;
+    *asc_enabled = (uint8_t)word;
 
     return STATUS_OK;
 }
 
-s16 scd_enable_automatic_self_calibration(u8 enable_asc) {
-    s16 ret;
-    u16 asc = !!enable_asc;
+int16_t scd_enable_automatic_self_calibration(uint8_t enable_asc) {
+    int16_t ret;
+    uint16_t asc = !!enable_asc;
 
     ret = sensirion_i2c_write_cmd_with_args(SCD_I2C_ADDRESS,
                                             SCD_CMD_AUTO_SELF_CALIBRATION, &asc,
@@ -170,8 +171,8 @@ s16 scd_enable_automatic_self_calibration(u8 enable_asc) {
     return ret;
 }
 
-s16 scd_set_forced_recalibration(u16 co2_ppm) {
-    s16 ret;
+int16_t scd_set_forced_recalibration(uint16_t co2_ppm) {
+    int16_t ret;
 
     ret = sensirion_i2c_write_cmd_with_args(
         SCD_I2C_ADDRESS, SCD_CMD_SET_FORCED_RECALIBRATION, &co2_ppm,
@@ -185,12 +186,12 @@ const char *scd_get_driver_version() {
     return SCD_DRV_VERSION_STR;
 }
 
-u8 scd_get_configured_address() {
+uint8_t scd_get_configured_address() {
     return SCD_I2C_ADDRESS;
 }
 
-s16 scd_probe() {
-    u16 data_ready;
+int16_t scd_probe() {
+    uint16_t data_ready;
 
     /* Initialize I2C */
     sensirion_i2c_init();

--- a/scd30/scd30.h
+++ b/scd30/scd30.h
@@ -44,7 +44,7 @@ extern "C" {
  *
  * @return  0 on success, an error code otherwise.
  */
-s16 scd_probe(void);
+int16_t scd_probe(void);
 
 /**
  * scd_get_driver_version() - Returns the driver version
@@ -56,9 +56,9 @@ const char *scd_get_driver_version(void);
 /**
  * scd_get_configured_address() - Returns the configured I2C address
  *
- * @return      u8 I2C address
+ * @return      uint8_t I2C address
  */
-u8 scd_get_configured_address(void);
+uint8_t scd_get_configured_address(void);
 
 /**
  * scd_start_periodic_measurement() - Start continuous measurement to measure
@@ -81,14 +81,14 @@ u8 scd_get_configured_address(void);
  * @return                      0 if the command was successful, an error code
  *                              otherwise
  */
-s16 scd_start_periodic_measurement(u16 ambient_pressure_mbar);
+int16_t scd_start_periodic_measurement(uint16_t ambient_pressure_mbar);
 
 /**
  * scd_stop_periodic_measurement() - Stop the continuous measurement
  *
  * @return  0 if the command was successful, else an error code
  */
-s16 scd_stop_periodic_measurement(void);
+int16_t scd_stop_periodic_measurement(void);
 
 /**
  * scd_read_measurement() - Read out an available measurement when new
@@ -104,7 +104,8 @@ s16 scd_stop_periodic_measurement(void);
  *
  * @return              0 if the command was successful, an error code otherwise
  */
-s16 scd_read_measurement(f32 *co2_ppm, f32 *temperature, f32 *humidity);
+int16_t scd_read_measurement(float32_t *co2_ppm, float32_t *temperature,
+                             float32_t *humidity);
 
 /**
  * scd_set_measurement_interval() - Sets the measurement interval in continuous
@@ -119,7 +120,7 @@ s16 scd_read_measurement(f32 *co2_ppm, f32 *temperature, f32 *humidity);
  *
  * @return              0 if the command was successful, an error code otherwise
  */
-s16 scd_set_measurement_interval(u16 interval_sec);
+int16_t scd_set_measurement_interval(uint16_t interval_sec);
 
 /**
  * scd_get_data_ready() - Get data ready status
@@ -137,7 +138,7 @@ s16 scd_set_measurement_interval(u16 interval_sec);
  *
  * @return              0 if the command was successful, an error code otherwise
  */
-s16 scd_get_data_ready(u16 *data_ready);
+int16_t scd_get_data_ready(uint16_t *data_ready);
 
 /**
  * scd_set_temperature_offset() - Set the temperature offset
@@ -157,7 +158,7 @@ s16 scd_get_data_ready(u16 *data_ready);
  * @return                      0 if the command was successful, an error code
  *                              otherwise
  */
-s16 scd_set_temperature_offset(u16 temperature_offset);
+int16_t scd_set_temperature_offset(uint16_t temperature_offset);
 
 /**
  * scd_set_altitude() - Set the altitude above sea level
@@ -174,7 +175,7 @@ s16 scd_set_temperature_offset(u16 temperature_offset);
  *
  * @return          0 if the command was successful, an error code otherwise
  */
-s16 scd_set_altitude(u16 altitude);
+int16_t scd_set_altitude(uint16_t altitude);
 
 /**
  * scd_get_automatic_self_calibration() - Read if the sensor's automatic self
@@ -188,7 +189,7 @@ s16 scd_set_altitude(u16 altitude);
  *
  * @return              0 if the command was successful, an error code otherwise
  */
-s16 scd_get_automatic_self_calibration(u8 *asc_enabled);
+int16_t scd_get_automatic_self_calibration(uint8_t *asc_enabled);
 
 /**
  * scd_enable_automatic_self_calibration() - Enable or disable the sensor's
@@ -207,7 +208,7 @@ s16 scd_get_automatic_self_calibration(u8 *asc_enabled);
  *
  * @return              0 if the command was successful, an error code otherwise
  */
-s16 scd_enable_automatic_self_calibration(u8 enable_asc);
+int16_t scd_enable_automatic_self_calibration(uint8_t enable_asc);
 
 /**
  * scd_set_forced_recalibration() - Forcibly recalibrate the sensor to a known
@@ -231,7 +232,7 @@ s16 scd_enable_automatic_self_calibration(u8 enable_asc);
  *
  * @return          0 if the command was successful, an error code otherwise
  */
-s16 scd_set_forced_recalibration(u16 co2_ppm);
+int16_t scd_set_forced_recalibration(uint16_t co2_ppm);
 
 #ifdef __cplusplus
 }

--- a/scd30/scd30_example_usage.c
+++ b/scd30/scd30_example_usage.c
@@ -41,10 +41,10 @@
 #define usleep(...)
 
 int main(void) {
-    f32 co2_ppm, temperature, relative_humidity;
-    u16 data_ready;
-    s16 ret;
-    s16 interval_in_seconds = 2;
+    float32_t co2_ppm, temperature, relative_humidity;
+    uint16_t data_ready;
+    int16_t ret;
+    int16_t interval_in_seconds = 2;
 
     /* Busy loop for initialization, because the main loop does not work without
      * a sensor.


### PR DESCRIPTION
This patch includes the changes from the following commands:

    find . -type f \
        \( -name '*\.[ch]' -o -name '*\.cpp' -o -name '*\.ino' \) -print0 \
        | xargs -0 sed -i \
        -e 's/\bu\([0-9]\{1,2\}\)\b/uint\1_t/g' \
        -e 's/\bs\([0-9]\{1,2\}\)\b/int\1_t/g' \
        -e 's/\bf32\b/float32_t/g'

This commit updates embedded-common