### PR TITLE
Move sensirion_i2c_init from probe to example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`changed`]  Move the i2c init call out of `probe()` and into the example
+
 ## [1.0.0] - 2019-05-14
 
  * `[fixed]` Add processing delay on i2c writes

--- a/scd30/scd30.c
+++ b/scd30/scd30.c
@@ -193,9 +193,6 @@ uint8_t scd_get_configured_address() {
 int16_t scd_probe() {
     uint16_t data_ready;
 
-    /* Initialize I2C */
-    sensirion_i2c_init();
-
     /* try to read data-ready state */
     return scd_get_data_ready(&data_ready);
 }

--- a/scd30/scd30_example_usage.c
+++ b/scd30/scd30_example_usage.c
@@ -46,6 +46,9 @@ int main(void) {
     int16_t ret;
     int16_t interval_in_seconds = 2;
 
+    /* Initialize I2C */
+    sensirion_i2c_init();
+
     /* Busy loop for initialization, because the main loop does not work without
      * a sensor.
      */


### PR DESCRIPTION
This consitutes an interface change since the bus now has to be
enabled manually.