### PR TITLE
Copy correct files to release directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 depending on `CONFIG_I2C_TYPE`. Defaults to `hw_i2c`.
  * [`fixed`]    Fix clock stretching timeout that might occur when
                 `CONFIG_I2C_TYPE` is set to `sw_i2c`
+ * [`fixed`]    Copy correct `AUTHORS`, `CHANGELOG.md`, `LICENSE`, and
+                `README.md` files to target locations when running the `release`
+                target of the driver's root Makefile.
 
 ## [1.0.0] - 2019-05-14
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ $(release_drivers): scd-common/scd_git_version.c
 	cp -r embedded-common/* "$${pkgdir}" && \
 	cp -r scd-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
+	cp AUTHORS CHANGELOG.md README.md LICENSE "$${pkgdir}" && \
 	echo 'scd_driver_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'scd_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \


### PR DESCRIPTION
The files `AUTHORS`, `CHANGELOG.md`, `LICENSE`, and `README.md` in the
release directories were copied from the `embedded-common` submodule
instead of the driver's root folder. Fix this issue by overwriting the
files with the correct files.