### PR TITLE
Remove AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,0 @@
-Andreas Brauchli <andreas.brauchli@sensirion.com>
-Sven Gruebel <sven.gruebel@sensirion.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * [`fixed`]    Copy correct `AUTHORS`, `CHANGELOG.md`, `LICENSE`, and
                 `README.md` files to target locations when running the `release`
                 target of the driver's root Makefile.
+ * [`removed`]  Remove the `AUTHORS` file from the driver and the
+                `embedded-common` submodule, as it adds more noise than benefit.
+                The contributors can be found in the git log.
 
 ## [1.0.0] - 2019-05-14
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(release_drivers): scd-common/scd_git_version.c
 	cp -r embedded-common/* "$${pkgdir}" && \
 	cp -r scd-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
-	cp AUTHORS CHANGELOG.md README.md LICENSE "$${pkgdir}" && \
+	cp CHANGELOG.md LICENSE "$${pkgdir}" && \
 	echo 'scd_driver_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'scd_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \


### PR DESCRIPTION
The AUTHORS file adds more noise than benefit. The contributors can be
found in the git log. Additionally, some mail addresses might be
outdated.

This commit also updates the `embedded-common` submodule to also remove
the AUTHORS file there.