### PR TITLE
Move CHANGELOG items from 2.0.0 section to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`fixed`]    Copy correct `AUTHORS`, `CHANGELOG.md`, `LICENSE`, and
+                `README.md` files to target locations when running the `release`
+                target of the driver's root Makefile.
+ * [`removed`]  Remove the `AUTHORS` file from the driver and the
+                `embedded-common` submodule, as it adds more noise than benefit.
+                The contributors can be found in the git log.
+
 ## [2.0.0] - 2019-10-01
 
  * [`changed`]  Functions are now dedicated per sensor (e.g. `scd30_probe()`
@@ -20,12 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 depending on `CONFIG_I2C_TYPE`. Defaults to `hw_i2c`.
  * [`fixed`]    Fix clock stretching timeout that might occur when
                 `CONFIG_I2C_TYPE` is set to `sw_i2c`
- * [`fixed`]    Copy correct `AUTHORS`, `CHANGELOG.md`, `LICENSE`, and
-                `README.md` files to target locations when running the `release`
-                target of the driver's root Makefile.
- * [`removed`]  Remove the `AUTHORS` file from the driver and the
-                `embedded-common` submodule, as it adds more noise than benefit.
-                The contributors can be found in the git log.
 
 ## [1.0.0] - 2019-05-14
 


### PR DESCRIPTION
These changes happened after the 2.0.0 release.