### PR TITLE
Fix typo in header guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`fixed`]    Fix typo in header include-guard now.
+
 ## [2.0.2] - 2019-11-01
 
  * [`fixed`]    SCD30: Fix buffer overflow when reading measurements that was

--- a/scd-common/scd_git_version.h
+++ b/scd-common/scd_git_version.h
@@ -29,9 +29,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GIT_VERSION_H
-#define GIT_VERSION_H
+#ifndef SCD_GIT_VERSION_H
+#define SCD_GIT_VERSION_H
 
 extern const char *SCD_DRV_VERSION_STR;
 
-#endif /* GIT_VERSION_H */
+#endif /* SCD_GIT_VERSION_H */


### PR DESCRIPTION
Now called SCD_GIT_VERSION_H instead of just GIT_VERSION_H

Check the following:

 - [ ] ~~Breaking changes marked in commit message~~
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [ ] ~~Tested on actual hardware~~
