### PR TITLE
Remove float32_t typedef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
  * [`fixed`]    Fix typo in header include-guard now.
+ * [`changed`]  Use `float` instead of the custom `float32_t` type
 
 ## [2.0.2] - 2019-11-01
 

--- a/scd30/scd30.c
+++ b/scd30/scd30.c
@@ -75,12 +75,12 @@ int16_t scd30_stop_periodic_measurement() {
                                    SCD30_CMD_STOP_PERIODIC_MEASUREMENT);
 }
 
-int16_t scd30_read_measurement(float32_t *co2_ppm, float32_t *temperature,
-                               float32_t *humidity) {
+int16_t scd30_read_measurement(float *co2_ppm, float *temperature,
+                               float *humidity) {
     int16_t ret;
     union {
         uint32_t u32_value;
-        float32_t float32;
+        float float32;
         uint8_t bytes[4];
     } tmp, data[3];
 

--- a/scd30/scd30.h
+++ b/scd30/scd30.h
@@ -104,8 +104,8 @@ int16_t scd30_stop_periodic_measurement(void);
  *
  * @return              0 if the command was successful, an error code otherwise
  */
-int16_t scd30_read_measurement(float32_t *co2_ppm, float32_t *temperature,
-                               float32_t *humidity);
+int16_t scd30_read_measurement(float *co2_ppm, float *temperature,
+                               float *humidity);
 
 /**
  * scd30_set_measurement_interval() - Sets the measurement interval in

--- a/scd30/scd30_example_usage.c
+++ b/scd30/scd30_example_usage.c
@@ -39,7 +39,7 @@
  */
 
 int main(void) {
-    float32_t co2_ppm, temperature, relative_humidity;
+    float co2_ppm, temperature, relative_humidity;
     int16_t err;
     uint16_t interval_in_seconds = 2;
 


### PR DESCRIPTION
float32_t is removed from latest embedded-common
* Replace use of float32_t types with float
* Update embedded-common

Check the following:

 - [x] ~~Breaking changes marked in commit message~~
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
