### PR TITLE
Fix readout error with drifting clocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  * [`changed`] Makefile to only include needed files from embedded-common
  * [`fixed`]   Fix bug where data ready flag could not be read.
+ * [`fixed`]   Fix readout error with drifting clocks by polling data ready flag
 
 ## [2.1.0] - 2020-07-08
 

--- a/scd30/scd30.c
+++ b/scd30/scd30.c
@@ -77,18 +77,18 @@ int16_t scd30_stop_periodic_measurement() {
 
 int16_t scd30_read_measurement(float* co2_ppm, float* temperature,
                                float* humidity) {
-    int16_t ret;
+    int16_t error;
     uint8_t data[3][4];
 
-    ret =
+    error =
         sensirion_i2c_write_cmd(SCD30_I2C_ADDRESS, SCD30_CMD_READ_MEASUREMENT);
-    if (ret != NO_ERROR)
-        return ret;
+    if (error != NO_ERROR)
+        return error;
 
-    ret = sensirion_i2c_read_words_as_bytes(SCD30_I2C_ADDRESS, &data[0][0],
-                                            SENSIRION_NUM_WORDS(data));
-    if (ret != NO_ERROR)
-        return ret;
+    error = sensirion_i2c_read_words_as_bytes(SCD30_I2C_ADDRESS, &data[0][0],
+                                              SENSIRION_NUM_WORDS(data));
+    if (error != NO_ERROR)
+        return error;
 
     *co2_ppm = sensirion_bytes_to_float(data[0]);
     *temperature = sensirion_bytes_to_float(data[1]);
@@ -98,19 +98,19 @@ int16_t scd30_read_measurement(float* co2_ppm, float* temperature,
 }
 
 int16_t scd30_set_measurement_interval(uint16_t interval_sec) {
-    int16_t ret;
+    int16_t error;
 
     if (interval_sec < 2 || interval_sec > 1800) {
         /* out of allowable range */
         return STATUS_FAIL;
     }
 
-    ret = sensirion_i2c_write_cmd_with_args(
+    error = sensirion_i2c_write_cmd_with_args(
         SCD30_I2C_ADDRESS, SCD30_CMD_SET_MEASUREMENT_INTERVAL, &interval_sec,
         SENSIRION_NUM_WORDS(interval_sec));
     sensirion_sleep_usec(SCD30_WRITE_DELAY_US);
 
-    return ret;
+    return error;
 }
 
 int16_t scd30_get_data_ready(uint16_t* data_ready) {
@@ -120,36 +120,36 @@ int16_t scd30_get_data_ready(uint16_t* data_ready) {
 }
 
 int16_t scd30_set_temperature_offset(uint16_t temperature_offset) {
-    int16_t ret;
+    int16_t error;
 
-    ret = sensirion_i2c_write_cmd_with_args(
+    error = sensirion_i2c_write_cmd_with_args(
         SCD30_I2C_ADDRESS, SCD30_CMD_SET_TEMPERATURE_OFFSET,
         &temperature_offset, SENSIRION_NUM_WORDS(temperature_offset));
     sensirion_sleep_usec(SCD30_WRITE_DELAY_US);
 
-    return ret;
+    return error;
 }
 
 int16_t scd30_set_altitude(uint16_t altitude) {
-    int16_t ret;
+    int16_t error;
 
-    ret = sensirion_i2c_write_cmd_with_args(SCD30_I2C_ADDRESS,
-                                            SCD30_CMD_SET_ALTITUDE, &altitude,
-                                            SENSIRION_NUM_WORDS(altitude));
+    error = sensirion_i2c_write_cmd_with_args(SCD30_I2C_ADDRESS,
+                                              SCD30_CMD_SET_ALTITUDE, &altitude,
+                                              SENSIRION_NUM_WORDS(altitude));
     sensirion_sleep_usec(SCD30_WRITE_DELAY_US);
 
-    return ret;
+    return error;
 }
 
 int16_t scd30_get_automatic_self_calibration(uint8_t* asc_enabled) {
     uint16_t word;
-    int16_t ret;
+    int16_t error;
 
-    ret = sensirion_i2c_read_cmd(SCD30_I2C_ADDRESS,
-                                 SCD30_CMD_AUTO_SELF_CALIBRATION, &word,
-                                 SENSIRION_NUM_WORDS(word));
-    if (ret != NO_ERROR)
-        return ret;
+    error = sensirion_i2c_read_cmd(SCD30_I2C_ADDRESS,
+                                   SCD30_CMD_AUTO_SELF_CALIBRATION, &word,
+                                   SENSIRION_NUM_WORDS(word));
+    if (error != NO_ERROR)
+        return error;
 
     *asc_enabled = (uint8_t)word;
 
@@ -157,40 +157,40 @@ int16_t scd30_get_automatic_self_calibration(uint8_t* asc_enabled) {
 }
 
 int16_t scd30_enable_automatic_self_calibration(uint8_t enable_asc) {
-    int16_t ret;
+    int16_t error;
     uint16_t asc = !!enable_asc;
 
-    ret = sensirion_i2c_write_cmd_with_args(SCD30_I2C_ADDRESS,
-                                            SCD30_CMD_AUTO_SELF_CALIBRATION,
-                                            &asc, SENSIRION_NUM_WORDS(asc));
+    error = sensirion_i2c_write_cmd_with_args(SCD30_I2C_ADDRESS,
+                                              SCD30_CMD_AUTO_SELF_CALIBRATION,
+                                              &asc, SENSIRION_NUM_WORDS(asc));
     sensirion_sleep_usec(SCD30_WRITE_DELAY_US);
 
-    return ret;
+    return error;
 }
 
 int16_t scd30_set_forced_recalibration(uint16_t co2_ppm) {
-    int16_t ret;
+    int16_t error;
 
-    ret = sensirion_i2c_write_cmd_with_args(
+    error = sensirion_i2c_write_cmd_with_args(
         SCD30_I2C_ADDRESS, SCD30_CMD_SET_FORCED_RECALIBRATION, &co2_ppm,
         SENSIRION_NUM_WORDS(co2_ppm));
     sensirion_sleep_usec(SCD30_WRITE_DELAY_US);
 
-    return ret;
+    return error;
 }
 
 int16_t scd30_read_serial(char* serial) {
-    int16_t ret;
+    int16_t error;
 
-    ret = sensirion_i2c_write_cmd(SCD30_I2C_ADDRESS, SCD30_CMD_READ_SERIAL);
-    if (ret)
-        return ret;
+    error = sensirion_i2c_write_cmd(SCD30_I2C_ADDRESS, SCD30_CMD_READ_SERIAL);
+    if (error)
+        return error;
 
     sensirion_sleep_usec(SCD30_WRITE_DELAY_US);
-    ret = sensirion_i2c_read_words_as_bytes(SCD30_I2C_ADDRESS, (uint8_t*)serial,
-                                            SCD30_SERIAL_NUM_WORDS);
+    error = sensirion_i2c_read_words_as_bytes(
+        SCD30_I2C_ADDRESS, (uint8_t*)serial, SCD30_SERIAL_NUM_WORDS);
     serial[2 * SCD30_SERIAL_NUM_WORDS] = '\0';
-    return ret;
+    return error;
 }
 
 const char* scd30_get_driver_version() {

--- a/scd30/scd30.c
+++ b/scd30/scd30.c
@@ -82,19 +82,19 @@ int16_t scd30_read_measurement(float* co2_ppm, float* temperature,
 
     ret =
         sensirion_i2c_write_cmd(SCD30_I2C_ADDRESS, SCD30_CMD_READ_MEASUREMENT);
-    if (ret != STATUS_OK)
+    if (ret != NO_ERROR)
         return ret;
 
     ret = sensirion_i2c_read_words_as_bytes(SCD30_I2C_ADDRESS, &data[0][0],
                                             SENSIRION_NUM_WORDS(data));
-    if (ret != STATUS_OK)
+    if (ret != NO_ERROR)
         return ret;
 
     *co2_ppm = sensirion_bytes_to_float(data[0]);
     *temperature = sensirion_bytes_to_float(data[1]);
     *humidity = sensirion_bytes_to_float(data[2]);
 
-    return STATUS_OK;
+    return NO_ERROR;
 }
 
 int16_t scd30_set_measurement_interval(uint16_t interval_sec) {
@@ -148,12 +148,12 @@ int16_t scd30_get_automatic_self_calibration(uint8_t* asc_enabled) {
     ret = sensirion_i2c_read_cmd(SCD30_I2C_ADDRESS,
                                  SCD30_CMD_AUTO_SELF_CALIBRATION, &word,
                                  SENSIRION_NUM_WORDS(word));
-    if (ret != STATUS_OK)
+    if (ret != NO_ERROR)
         return ret;
 
     *asc_enabled = (uint8_t)word;
 
-    return STATUS_OK;
+    return NO_ERROR;
 }
 
 int16_t scd30_enable_automatic_self_calibration(uint8_t enable_asc) {

--- a/scd30/scd30_example_usage.c
+++ b/scd30/scd30_example_usage.c
@@ -58,9 +58,31 @@ int main(void) {
     scd30_set_measurement_interval(interval_in_seconds);
     sensirion_sleep_usec(20000u);
     scd30_start_periodic_measurement(0);
-    sensirion_sleep_usec(interval_in_seconds * 1000000u);
 
     while (1) {
+        uint16_t data_ready = 0;
+        uint16_t timeout = 0;
+
+        /* Poll data_ready flag until data is available. Allow %20 more than
+         * the measurement interval to account for clock imprecision of the
+         * sensor.
+         */
+        for (timeout = 0; (100000 * timeout) < (interval_in_seconds * 1200000);
+             ++timeout) {
+            err = scd30_get_data_ready(&data_ready);
+            if (err != NO_ERROR) {
+                printf("Error reading data_ready flag: %i\n", err);
+            }
+            if (data_ready) {
+                break;
+            }
+            sensirion_sleep_usec(100000);
+        }
+        if (!data_ready) {
+            printf("Timeout waiting for data_ready flag\n");
+            continue;
+        }
+
         /* Measure co2, temperature and relative humidity and store into
          * variables.
          */
@@ -75,8 +97,6 @@ int main(void) {
                    "measured humidity: %0.2f %%RH\n",
                    co2_ppm, temperature, relative_humidity);
         }
-
-        sensirion_sleep_usec(interval_in_seconds * 1000000u);
     }
 
     scd30_stop_periodic_measurement();

--- a/scd30/scd30_example_usage.c
+++ b/scd30/scd30_example_usage.c
@@ -63,7 +63,7 @@ int main(void) {
         uint16_t data_ready = 0;
         uint16_t timeout = 0;
 
-        /* Poll data_ready flag until data is available. Allow %20 more than
+        /* Poll data_ready flag until data is available. Allow 20% more than
          * the measurement interval to account for clock imprecision of the
          * sensor.
          */

--- a/scd30/scd30_example_usage.c
+++ b/scd30/scd30_example_usage.c
@@ -49,7 +49,7 @@ int main(void) {
     /* Busy loop for initialization, because the main loop does not work without
      * a sensor.
      */
-    while (scd30_probe() != STATUS_OK) {
+    while (scd30_probe() != NO_ERROR) {
         printf("SCD30 sensor probing failed\n");
         sensirion_sleep_usec(1000000u);
     }
@@ -66,7 +66,7 @@ int main(void) {
          */
         err =
             scd30_read_measurement(&co2_ppm, &temperature, &relative_humidity);
-        if (err != STATUS_OK) {
+        if (err != NO_ERROR) {
             printf("error reading measurement\n");
 
         } else {


### PR DESCRIPTION
If the sensirion_sleep_usec sleeps longer or shorter, the readout will
fail at some point, since we will miss the readout window of 100ms at
one point or another. By waiting less then the measurement interval and
then starting to poll the data ready flag we should fix the issue,
except if the sleep time is off by more than 100ms.

Fixes #43 

Check the following:

 - [na] Breaking changes marked in commit message
 - [X] Changelog updated
 - [X] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
