### PR TITLE
Add 3ms delay when reading data ready flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
  * [`changed`] Makefile to only include needed files from embedded-common
+ * [`fixed`]   Fix bug where data ready flag could not be read.
 
 ## [2.1.0] - 2020-07-08
 

--- a/scd30/scd30.c
+++ b/scd30/scd30.c
@@ -114,8 +114,9 @@ int16_t scd30_set_measurement_interval(uint16_t interval_sec) {
 }
 
 int16_t scd30_get_data_ready(uint16_t* data_ready) {
-    return sensirion_i2c_read_cmd(SCD30_I2C_ADDRESS, SCD30_CMD_GET_DATA_READY,
-                                  data_ready, SENSIRION_NUM_WORDS(*data_ready));
+    return sensirion_i2c_delayed_read_cmd(
+        SCD30_I2C_ADDRESS, SCD30_CMD_GET_DATA_READY, 3000, data_ready,
+        SENSIRION_NUM_WORDS(*data_ready));
 }
 
 int16_t scd30_set_temperature_offset(uint16_t temperature_offset) {


### PR DESCRIPTION
As reported in #43 according to the datasheet:
> the read header should be send with a delay of > 3ms following the
>  write sequence.

Check the following:

 - [na] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
