### PR TITLE
Prepare CHANGELOG for 2.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
- * [`changed`] Makefile to only include needed files from embedded-common
+## [2.1.1] - 2020-11-05
+
+ * [`changed`] Only include needed files from embedded-common in release zip
  * [`fixed`]   Fix bug where data ready flag could not be read.
- * [`fixed`]   Fix readout error with drifting clocks by polling data ready flag
+ * [`fixed`]   Fix readout error with drifting clocks by polling data ready
+               flag.
 
 ## [2.1.0] - 2020-07-08
 
@@ -68,7 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  * Initial support for SCD30
 
-[Unreleased]: https://github.com/Sensirion/embedded-scd/compare/2.1.0...master
+[Unreleased]: https://github.com/Sensirion/embedded-scd/compare/2.1.1...master
+[2.1.1]: https://github.com/Sensirion/embedded-scd/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/Sensirion/embedded-scd/compare/2.0.2...2.1.0
 [2.0.2]: https://github.com/Sensirion/embedded-scd/compare/2.0.1...2.0.2
 [2.0.1]: https://github.com/Sensirion/embedded-scd/compare/2.0.0...2.0.1


### PR DESCRIPTION
Check the following:

 - [na] Breaking changes marked in commit message
 - [X] Changelog updated
 - [na] Code style cleaned (ran `make style-fix`)
 - [na] Tested on actual hardware
